### PR TITLE
Fix: macOSでWebView内の描画範囲がおかしい問題を修正

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,10 @@ unsafe extern "C-unwind" fn plugin_ui_new(
     plugin: &Plugin,
     width: usize,
     height: usize,
+    scale_factor: f64,
 ) -> *mut PluginUi {
     let plugin_ref = Arc::clone(&plugin.inner);
-    let plugin_ui = match ui::PluginUiImpl::new(handle, plugin_ref, width, height) {
+    let plugin_ui = match ui::PluginUiImpl::new(handle, plugin_ref, width, height, scale_factor) {
         Ok(plugin_ui) => {
             info!("PluginUi created");
             plugin_ui
@@ -145,9 +146,14 @@ unsafe extern "C-unwind" fn plugin_ui_new(
 }
 
 #[no_mangle]
-unsafe extern "C-unwind" fn plugin_ui_set_size(plugin_ui: &PluginUi, width: usize, height: usize) {
+unsafe extern "C-unwind" fn plugin_ui_set_size(
+    plugin_ui: &PluginUi,
+    width: usize,
+    height: usize,
+    scale_factor: f64,
+) {
     let plugin_ui = plugin_ui.inner.blocking_lock();
-    if let Err(err) = plugin_ui.set_size(width, height) {
+    if let Err(err) = plugin_ui.set_size(width, height, scale_factor) {
         error!("Failed to set size: {}", err);
     }
 }

--- a/src/rust.generated.hpp
+++ b/src/rust.generated.hpp
@@ -52,9 +52,10 @@ EXPORT
 PluginUi *plugin_ui_new(uintptr_t handle,
                         const Plugin *plugin,
                         uintptr_t width,
-                        uintptr_t height);
+                        uintptr_t height,
+                        double scale_factor);
 
-EXPORT void plugin_ui_set_size(const PluginUi *plugin_ui, uintptr_t width, uintptr_t height);
+EXPORT void plugin_ui_set_size(const PluginUi *plugin_ui, uintptr_t width, uintptr_t height, double scale_factor);
 
 EXPORT void plugin_ui_idle(const PluginUi *plugin_ui);
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -42,9 +42,8 @@ public:
     if (!inner) {
       return;
     }
-    auto scaleFactor = this->getScaleFactor();
-    Rust::plugin_ui_set_size(inner.get(), width * scaleFactor,
-                             height * scaleFactor);
+    auto scale_factor = this->getScaleFactor();
+    Rust::plugin_ui_set_size(inner.get(), width, height, scale_factor);
   }
 
 private:
@@ -55,15 +54,19 @@ private:
   void initializeRustUi() {
     auto lock = std::unique_lock(this->mutex);
     if (inner) {
-      return;
+        return;
     }
     auto plugin = static_cast<VvvstPlugin *>(this->getPluginInstancePointer());
-    auto scaleFactor = this->getScaleFactor();
     inner = std::shared_ptr<Rust::PluginUi>(
-        Rust::plugin_ui_new(this->getParentWindowHandle(), plugin->inner.get(),
-                            this->getWidth() * scaleFactor,
-                            this->getHeight() * scaleFactor),
-        [](Rust::PluginUi *inner) { Rust::plugin_ui_drop(inner); });
+        Rust::plugin_ui_new(
+            this->getParentWindowHandle(),
+            plugin->inner.get(),
+            this->getWidth(),
+            this->getHeight(),
+            this->getScaleFactor()
+        ),
+        [](Rust::PluginUi *inner) { Rust::plugin_ui_drop(inner); }
+    );
     if (!inner) {
       return;
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -190,11 +190,9 @@ impl PluginUiImpl {
     }
 
     pub fn set_size(&self, width: usize, height: usize, scale_factor: f64) -> Result<()> {
-        let scaled_width = (width as f64 / scale_factor) as u32;
-        let scaled_height = (height as f64 / scale_factor) as u32;
         self.webview.set_bounds(wry::Rect {
             position: winit::dpi::LogicalPosition::new(0.0, 0.0).into(),
-            size: winit::dpi::LogicalSize::new(scaled_width as f64, scaled_height as f64).into(),
+            size: winit::dpi::LogicalSize::new(width as f64 / scale_factor, height as f64 / scale_factor).into(),
         })?;
         Ok(())
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -35,6 +35,7 @@ impl PluginUiImpl {
         plugin: Arc<Mutex<PluginImpl>>,
         width: usize,
         height: usize,
+        scale_factor: f64,
     ) -> Result<Self> {
         let raw_window_handle = if cfg!(target_os = "windows") {
             raw_window_handle::RawWindowHandle::Win32(raw_window_handle::Win32WindowHandle::new(
@@ -72,7 +73,7 @@ impl PluginUiImpl {
         let webview_builder = wry::WebViewBuilder::with_web_context(&mut web_context)
             .with_bounds(wry::Rect {
                 position: winit::dpi::LogicalPosition::new(0.0, 0.0).into(),
-                size: winit::dpi::LogicalSize::new(width as f64, height as f64).into(),
+                size: winit::dpi::LogicalSize::new(width as f64 / scale_factor, height as f64 / scale_factor).into(),
             })
             .with_clipboard(true)
             .with_background_color((165, 212, 173, 255))
@@ -188,12 +189,13 @@ impl PluginUiImpl {
         Ok(())
     }
 
-    pub fn set_size(&self, width: usize, height: usize) -> Result<()> {
+    pub fn set_size(&self, width: usize, height: usize, scale_factor: f64) -> Result<()> {
+        let scaled_width = (width as f64 / scale_factor) as u32;
+        let scaled_height = (height as f64 / scale_factor) as u32;
         self.webview.set_bounds(wry::Rect {
             position: winit::dpi::LogicalPosition::new(0.0, 0.0).into(),
-            size: winit::dpi::LogicalSize::new(width as f64, height as f64).into(),
+            size: winit::dpi::LogicalSize::new(scaled_width as f64, scaled_height as f64).into(),
         })?;
-
         Ok(())
     }
 


### PR DESCRIPTION
## 概要

以下の問題を修正します。

- (少なくとも)macOSでWebView内の描画範囲がおかしい問題を修正

## 備考

scale_factorを渡してUI作成時およびウインドウサイズ変更時のwidth/heightを変更しています
(なぜなのかは詳しくなくよくわかっていないです...)

これうまくやればスケーリング機能追加できないかな…

## スクリーンショット

### 今回の変更前
dpi対応修正後のmainブランチです
左中央から1/2範囲しか表示されず・スクロールしても同様
<img width="1728" alt="スクリーンショット 2024-11-03 1 56 00" src="https://github.com/user-attachments/assets/713cf415-9ffc-4a5d-baba-c70db51e2eb3">

### 今
<img width="1728" alt="スクリーンショット 2024-11-03 10 26 20" src="https://github.com/user-attachments/assets/6bb844a5-e45b-4592-b4d0-559e78d6379b">
回の変更後
